### PR TITLE
pdf _to_json functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ API with `main_api_local.py` (both backend).
 > **Ensure the environment has been configured before setting up or updating the vector store.**
 
 Before running `pdf_runner.py` in an integrated development environment (IDE) ensure that the PDF_FILES_MODE (in `main.toml`) 
-is set to the desired option. It can also be run in the command line as below.
+is set to the desired option along with the chosen PDF extractor. It can also be run in the command line as below.
 
     ```shell
     python3 statschat/pdf_runner.py

--- a/docs/config_guide.md
+++ b/docs/config_guide.md
@@ -17,6 +17,7 @@ This guide explains the configuration options for StatsChat. The configuration f
 - **split_length**: Maximum number of characters per split document.
 - **split_overlap**: Number of overlapping characters between splits.
 - **latest_only**: If `true`, only process the latest files.
+- **extractor**: Choose which PDF extractor is used for JSON conversion - `pypdf`,`fitz` or `pdfplumber`
 
 ## `[search]`
 

--- a/statschat/config/main.toml
+++ b/statschat/config/main.toml
@@ -11,6 +11,7 @@ split_directory = "json_split"
 split_length = 2000
 split_overlap = 200
 latest_only = false
+extractor = "pypdf" # Options: "pypdf", "fitz", "pdfplumber"
 
 [search]
 generative_model_name = "mistralai/Mistral-7B-Instruct-v0.3"  # "text-unicorn" "text-bison@001" "google/flan-t5-large" "lmsys/fastchat-t5-3b-v1.0" "google/flan-t5-large" "google/flan-ul2"

--- a/statschat/pdf_processing/pdf_to_json.py
+++ b/statschat/pdf_processing/pdf_to_json.py
@@ -110,7 +110,6 @@ def get_name_and_meta(pdf_file_path: Path, config: dict) -> tuple[str, dict]:
     return file_name, pdf_metadata
 
 
-
 def extract_url_keywords_from_filename(file_name: str) -> list[str]:
     """
     Extracts unique keywords from a hyphen-separated filename while
@@ -232,7 +231,7 @@ def extract_pdf_modification_date(metadata, pdf_creation_date: str) -> str:
         return pdf_creation_date
 
 
-def extract_pdf_metadata(pdf_file_path: Path) -> tuple:
+def extract_pdf_metadata(pdf_file_path: Path, config: dict) -> tuple:
     """
     Extracts metadata from a given PDF file.
 
@@ -241,12 +240,11 @@ def extract_pdf_metadata(pdf_file_path: Path) -> tuple:
         counter (int): A running count of files missing reliable date information.
 
     Returns:
-        tuple: (file_name, pdf_year, pdf_month,
-                pdf_creation_date, pdf_metadata, updated_counter)
+        tuple: (file_name, pdf_metadata)
     """
 
     # Extract filename and metadata
-    file_name, pdf_metadata = get_name_and_meta(pdf_file_path)
+    file_name, pdf_metadata = get_name_and_meta(pdf_file_path, config)
     # Extract creation and modification dates
 
     return file_name, pdf_metadata
@@ -448,7 +446,7 @@ def convert_to_date(date_str: str) -> str:
 
 
 def build_json(
-    pdf_file_path: Path, pdf_website_url: str, report_page: str, JSON_DIR: Path
+    pdf_file_path: Path, pdf_website_url: str, report_page: str, JSON_DIR: Path, config
 ) -> int:
     """
     Processes a PDF file, extracts metadata and content, then saves it as JSON.
@@ -501,7 +499,7 @@ def build_json(
         "contact_name": "Kenya National Bureau of Statistics",  # Contact details
         "contact_link": "datarequest@knbs.or.ke",
         "content": extract_pdf_text(
-            pdf_file_path, pdf_url
+            pdf_file_path, pdf_url, config
         ),  # Extracted text at the end
     }
     # check if overview is equal to the title
@@ -599,7 +597,7 @@ def process_pdfs(mode: str, config: dict):
         report_page = url_dict.get(f"{pdf}.pdf", {}).get(
             "report_page", "Unknown Overview URL"
         )
-        build_json(pdf_path, pdf_url, report_page, json_dir)
+        build_json(pdf_path, pdf_url, report_page, json_dir, config)
         count += 1
 
     print(f"Processed {count} PDFs. JSON files saved to {json_dir}.")

--- a/statschat/pdf_processing/pdf_to_json.py
+++ b/statschat/pdf_processing/pdf_to_json.py
@@ -1,7 +1,6 @@
 # %%
 # import modules
 import os
-import PyPDF2
 import json
 import re
 from pathlib import Path
@@ -11,6 +10,10 @@ from tqdm import tqdm
 from bs4 import BeautifulSoup
 from urllib.request import Request, urlopen
 from datetime import datetime
+from pypdf import PdfReader
+import fitz  # PyMuPDF
+import pdfplumber
+import toml
 
 # %%
 # set relative paths
@@ -33,7 +36,6 @@ def load_config(config_path: Path) -> dict:
     Returns:
         dict: Parsed configuration as a dictionary.
     """
-    import toml
 
     return toml.load(config_path)
 
@@ -78,21 +80,35 @@ def generate_latest_dir(original_dir: Path) -> Path:
     return original_dir.parent / f"latest_{original_dir.name}"
 
 
-def get_name_and_meta(pdf_file_path):
-    """Extracts file name and metadata from PDF
+def get_name_and_meta(pdf_file_path: Path, config: dict) -> tuple[str, dict]:
+    """
+    Extract the file name and metadata from a PDF file using the specified extractor.
 
     Args:
-        file_path (path): file path for PDF file
+        pdf_file_path (Path): Path to the PDF file.
+        config (dict): Configuration dictionary containing the extractor setting.
 
     Returns:
-        file_name: file for PDF file
-        pdf_metadata: metadata for PDF (dates etc)
+        tuple[str, dict]: A tuple containing:
+            - file_name (str): The name of the PDF file.
+            - pdf_metadata (dict): Metadata extracted from the PDF (e.g., author, creation date).
     """
+    extractor = config["preprocess"]["extractor"]
     file_name = pdf_file_path.name
-    pdf_metadata = PyPDF2.PdfReader(pdf_file_path)
-    pdf_metadata = pdf_metadata.metadata
+    pdf_metadata = {}
 
-    return (file_name, pdf_metadata)
+    if extractor == "pypdf":
+        reader = PdfReader(pdf_file_path)
+        pdf_metadata = reader.metadata
+    elif extractor == "fitz":
+        doc = fitz.open(pdf_file_path)
+        pdf_metadata = doc.metadata
+    elif extractor == "pdfplumber":
+        with pdfplumber.open(pdf_file_path) as pdf:
+            pdf_metadata = pdf.metadata
+
+    return file_name, pdf_metadata
+
 
 
 def extract_url_keywords_from_filename(file_name: str) -> list[str]:
@@ -128,7 +144,7 @@ def extract_pdf_creation_date(metadata, filename: str, counter: int) -> tuple[st
     date from metadata, or the current system date as a final fallback.
 
     Args:
-        metadata: PDF metadata dictionary from PyPDF2.PdfReader (can be None).
+        metadata: PDF metadata dictionary from extractor (can be None).
         filename (str): The filename from which to extract a year if needed.
         counter (int): A running count of files that lack reliable date information.
 
@@ -140,7 +156,7 @@ def extract_pdf_creation_date(metadata, filename: str, counter: int) -> tuple[st
     pdf_creation_date = None  # Initialize variable to store the extracted date.
 
     def preprocess_date(date_str: str) -> str:
-        """Extracts only the YYYYMMDD portion from a PyPDF2 date string."""
+        """Extracts only the YYYYMMDD portion from a date string."""
         if date_str and date_str.startswith("D:"):
             date_str = date_str[2:10]  # Extract only YYYYMMDD
         return (
@@ -185,7 +201,7 @@ def extract_pdf_modification_date(metadata, pdf_creation_date: str) -> str:
     date.
 
     Args:
-        metadata: PDF metadata object from PyPDF2.PdfReader.
+        metadata: PDF metadata object.
         pdf_creation_date (str): The creation date to use as a fallback if
         modification date is missing or invalid.
 
@@ -236,35 +252,53 @@ def extract_pdf_metadata(pdf_file_path: Path) -> tuple:
     return file_name, pdf_metadata
 
 
-def extract_pdf_text(pdf_file_path: Path, pdf_url: str) -> list:
+def extract_pdf_text(pdf_file_path: Path, pdf_url: str, config: dict) -> list[dict]:
     """
-    Extracts text content from each page of a PDF file.
+    Extract text content from each page of a PDF file using the configured extractor.
 
     Args:
-        pdf_file_path (Path): The path to the PDF file.
-        pdf_url (str): The base URL where the document is hosted.
+        pdf_file_path (Path): Path to the PDF file.
+        pdf_url (str): Base URL where the document is hosted (used to build page links).
+        config (dict): Configuration dictionary containing the extractor setting.
 
     Returns:
-        list: A list of dictionaries containing page number, URL, and extracted text.
+        list[dict]: A list of dictionaries, each containing:
+            - page_number (int): The page number.
+            - page_url (str): The URL pointing to the specific page.
+            - page_text (str): Extracted text content from the page.
     """
-
+    extractor = config["preprocess"]["extractor"]
     pages_text = []
-    with open(pdf_file_path, "rb") as pdf_file:
-        pdf_reader = PyPDF2.PdfReader(pdf_file)
 
-        for page_num, page in enumerate(pdf_reader.pages, start=1):
-            text = page.extract_text()
-            if text:
-                text = text.replace("\n", "")
+    if extractor == "pypdf":
+        reader = PdfReader(pdf_file_path)
+        for page_num, page in enumerate(reader.pages, start=1):
+            text = (page.extract_text() or "").replace("\n", "")
+            pages_text.append({
+                "page_number": page_num,
+                "page_url": f"{pdf_url}#page={page_num}",
+                "page_text": text
+            })
 
-            page_link = f"{pdf_url}#page={page_num}"
-            pages_text.append(
-                {
+    elif extractor == "fitz":
+        doc = fitz.open(pdf_file_path)
+        for page_num, page in enumerate(doc, start=1):
+            text = (page.get_text("text") or "").replace("\n", "")
+            pages_text.append({
+                "page_number": page_num,
+                "page_url": f"{pdf_url}#page={page_num}",
+                "page_text": text
+            })
+
+    elif extractor == "pdfplumber":
+        with pdfplumber.open(pdf_file_path) as pdf:
+            for page_num, page in enumerate(pdf.pages, start=1):
+                text = (page.extract_text() or "").replace("\n", "")
+                pages_text.append({
                     "page_number": page_num,
-                    "page_url": page_link,
-                    "page_text": text or "",
-                }
-            )
+                    "page_url": f"{pdf_url}#page={page_num}",
+                    "page_text": text
+                })
 
     return pages_text
 

--- a/statschat/pdf_processing/pdf_to_json.py
+++ b/statschat/pdf_processing/pdf_to_json.py
@@ -466,7 +466,7 @@ def build_json(
     # print(f"Processing: {pdf_file_path.name}")
 
     # Extract Metadata & Pre-Process
-    file_name, pdf_metadata = extract_pdf_metadata(pdf_file_path)
+    file_name, pdf_metadata = extract_pdf_metadata(pdf_file_path, config)
 
     # Construct the document's URL
     pdf_url = pdf_website_url

--- a/statschat/pdf_processing/pdf_to_json.py
+++ b/statschat/pdf_processing/pdf_to_json.py
@@ -83,6 +83,7 @@ def generate_latest_dir(original_dir: Path) -> Path:
 def get_name_and_meta(pdf_file_path: Path, config: dict) -> tuple[str, dict]:
     """
     Extract the file name and metadata from a PDF file using the specified extractor.
+    Always normalize metadata to a plain dict with consistent keys.
 
     Args:
         pdf_file_path (Path): Path to the PDF file.
@@ -99,13 +100,18 @@ def get_name_and_meta(pdf_file_path: Path, config: dict) -> tuple[str, dict]:
 
     if extractor == "pypdf":
         reader = PdfReader(pdf_file_path)
-        pdf_metadata = reader.metadata
+        # Convert DocumentInformation to dict
+        pdf_metadata = {k: str(v) for k, v in reader.metadata.items() if v is not None}
+
     elif extractor == "fitz":
         doc = fitz.open(pdf_file_path)
-        pdf_metadata = doc.metadata
+        # Already a dict, but normalize keys
+        pdf_metadata = {k.lower(): v for k, v in doc.metadata.items() if v}
+
     elif extractor == "pdfplumber":
         with pdfplumber.open(pdf_file_path) as pdf:
-            pdf_metadata = pdf.metadata
+            pdf_metadata = {k.lower(): v for k, v in pdf.metadata.items() if v}
+
 
     return file_name, pdf_metadata
 


### PR DESCRIPTION
- Updated documentation
- Can now switch between PDF extractors using the `main.toml` for `pdf _to_json.py`
- Retains dict approach for metadata as to not effect downstream